### PR TITLE
2025-05-29-update-redis-caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,3 +147,5 @@ gem 'rest-client'
 gem 'rtesseract'
 
 gem 'multipart-post'
+
+gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -672,6 +672,8 @@ GEM
     raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6.2)
@@ -763,8 +765,24 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.5.1)
+    redis-actionpack (5.5.0)
+      actionpack (>= 5)
+      redis-rack (>= 2.1.0, < 4)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.3.0)
+      activesupport (>= 3, < 8)
+      redis-store (>= 1.3, < 2)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.11.0)
+      redis (>= 4, < 6)
     redlock (1.2.1)
       redis (>= 3.0.0, < 5.0)
     representable (3.1.1)
@@ -983,6 +1001,7 @@ DEPENDENCIES
   prawn
   puma (~> 4.3)
   rails (~> 5.1.6.2)
+  redis-rails
   rest-client
   riiif
   rsolr (>= 1.0)

--- a/config/environments/digcollhyrax01.rb
+++ b/config/environments/digcollhyrax01.rb
@@ -55,6 +55,11 @@ Rails.application.configure do
   #  config.cache_store = :null_store
   #end
 
+  # AR: Use redis for caching
+  config.action_controller.perform_caching = true
+  config.cache_store = :redis_store, "redis://localhost:6379/0/cache"
+  config.middleware.insert_before ActionDispatch::Static, NoCacheMiddleware, [/concern\/.*\/.*\/edit/, /concern\/.*\/.*\/new/, /dashboard\/.*\/.*\/edit/, /uploaded_collection_thumbnails/]
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false

--- a/config/environments/digcollhyrax02.rb
+++ b/config/environments/digcollhyrax02.rb
@@ -53,7 +53,11 @@ Rails.application.configure do
   #
   #  config.cache_store = :null_store
   #end
+
+  # AR: Use redis for caching
   config.action_controller.perform_caching = true
+  config.cache_store = :redis_store, "redis://localhost:6379/0/cache"
+  config.middleware.insert_before ActionDispatch::Static, NoCacheMiddleware, [/concern\/.*\/.*\/edit/, /concern\/.*\/.*\/new/, /dashboard\/.*\/.*\/edit/, /uploaded_collection_thumbnails/]
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -105,5 +109,4 @@ Rails.application.configure do
 
   # JL: For Devise account locking
   Rails.application.routes.default_url_options[:host] = 'http://digcoll-hyrax02.tcd.ie'
-
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,2 @@
+cache_work_iiif_manifest:
+  enabled: true

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -234,6 +234,8 @@ Hyrax.config do |config|
   config.upload_path = ->() { '/opt/app/hyrax/tmp/uploads/' }
   config.cache_path = ->() { '/opt/app/hyrax/tmp/uploads/cache/' }
 
+  config.feature_config_path = Rails.root.join('config', 'features.yml')
+
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
   config.derivatives_path = Rails.root.join('tmp', 'derivatives')


### PR DESCRIPTION
This is currently live on the secondary server, and the changes will persist once deployed.

When this PR is deployed to the primary server, it will configure the application to use Redis for caching via:  
`cache_store = :redis_store` as well as enable the cache_work_iiif_manifest for manifest caching.

# Story
Since Rails 5.1.6.2 does not include out-of-the-box support for `redis_cache_store`, we use the `redis-rails` gem instead. The cache store configuration for both the primary and secondary environments has been updated to:

```ruby
config.cache_store = :redis_store, "redis://localhost:6379/0/cache"
```

Note that this configuration does not rely on environment variables, as initially assumed.

# IIIF Manifest Caching Performance Gains

As a follow-up, we enabled the `cache_work_iiif_manifest` feature via Flipflop and confirmed it is active in production. This change leverages Redis-backed Rails caching to store IIIF manifest JSON responses.

## Benchmark Summary
We ran 20 total manifest load tests (10 before caching, 10 after). Here's the comparison:

| Metric                    | Before Caching | After Caching | Improvement |
|--------------------------|----------------|----------------|-------------|
| Avg manifest load time   | ~1.4 seconds    | ~0.56 seconds  | ~60% faster |
| Fastest manifest load    | ~0.53 seconds   | ~0.528 seconds | ~0% (already fast) |
| Slowest manifest load    | ~4.15 seconds   | ~0.58 seconds  | ~86% faster |

*Note:* First loads are still slower (~4.15s pre-caching), but caching improves performance dramatically for all subsequent requests.

This enhancement provides a much faster IIIF viewer experience and reduces repeated backend load.
