### PR TITLE
change the features.rb to yml for syntax error

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -1,2 +1,0 @@
-cache_work_iiif_manifest:
-  enabled: true

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,1 @@
+cache_work_iiif_manifest: true


### PR DESCRIPTION
change the features.rb to features.yml for syntax error during asset precompilation during deploy to secondary.